### PR TITLE
Add neo4j graph DB

### DIFF
--- a/examples/summarize_to_notion/docker-compose.yml
+++ b/examples/summarize_to_notion/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 
 services:
+  # Used as the kv store for dedup and message queue.
   redis:
     image: redis
     ports:
@@ -12,6 +13,16 @@ services:
       - redis_data:/dedup-data  # mount the Redis data volume into the container
     restart: always
     container_name: taotie-redis
+
+  # Used as the knowledge graph DB
+  neo4j:
+    image: neo4j:latest
+    container_name: my-neo4j
+    ports:
+      - 7474:7474
+      - 7687:7687
+    environment:
+      - NEO4J_AUTH=neo4j/taotie-knowledge-graph  # Change the password!
 
   taotie:
     build:


### PR DESCRIPTION
## Summary
Add neo4j as the DB for the knowledge graph.

## Test Plan
See the neo4j docker started.
<img width="1097" alt="Screenshot 2023-05-11 at 9 11 47 PM" src="https://github.com/small-thinking/taotie/assets/2237303/6b23bea9-3c99-42da-8214-ae570d3cc828">


See the web portal is working.
![Screenshot 2023-05-11 at 9 11 55 PM](https://github.com/small-thinking/taotie/assets/2237303/cfaf6ab1-3c97-444c-a5d5-ce259cec099c)


