### PR TITLE
Add pub sub buffer to redis queue

### DIFF
--- a/examples/summarize_to_notion/docker-compose.yml
+++ b/examples/summarize_to_notion/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: redis
     ports:
       - "6379:6379"
-    command: redis-server /usr/local/etc/redis/redis.conf
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf", "--client-output-buffer-limit", "pubsub 100mb 50mb 60"]
     volumes:
       # mount the local Redis configuration file into the container
       - ./examples/summarize_to_notion/redis.conf:/usr/local/etc/redis/redis.conf


### PR DESCRIPTION
## Summary
Add the pub sub buffer to redis queue. This would be useful as the sub processors is slower than the pub processor.

## Test Plan
Started the service and see the config is applied.
<img width="850" alt="Screenshot 2023-05-13 at 1 09 03 PM" src="https://github.com/small-thinking/taotie/assets/2237303/5badce6a-cf43-4fdf-ac88-3203d9b07f97">

